### PR TITLE
Update easy-conding-standard usage to 10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation & usage
 2. Import the configuration file in your `ecs.php`:
 
     ```php
-    $containerConfigurator->import('vendor/mobizel/coding-standard/ecs.php');
+    $ecsConfig->import('vendor/mobizel/coding-standard/ecs.php');
     ```
 
 Example config (ecs.php)
@@ -26,10 +26,10 @@ Example config (ecs.php)
 <?php
 
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import('vendor/mobizel/coding-standard/ecs.php');
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->import('vendor/mobizel/coding-standard/ecs.php');
 
     $header = <<<EOM
 This file is part of <The Project>.
@@ -40,7 +40,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 EOM;
 
-    $services = $containerConfigurator->services();
+    $services = $ecsConfig->services();
     $services
         ->set(HeaderCommentFixer::class)
         ->call('configure', [[

--- a/ecs.php
+++ b/ecs.php
@@ -12,13 +12,13 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitMethodCasingFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestClassRequiresCoversFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(SetList::SYMFONY);
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->import(SetList::PSR_12);
 
-    $services = $containerConfigurator->services();
+    $services = $ecsConfig->services();
     $services->set(DeclareStrictTypesFixer::class);
     $services->set(OrderedImportsFixer::class);
     $services->set(NoUnusedImportsFixer::class);
@@ -33,7 +33,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(TrailingCommaInMultilineFixer::class)
         ->call('configure', [['elements' => ['arrays', 'arguments', 'parameters']]]);
 
-    $parameters = $containerConfigurator->parameters();
+    $parameters = $ecsConfig->parameters();
     $parameters->set('skip', [
         VisibilityRequiredFixer::class => ['*Spec.php'],
         PhpUnitTestClassRequiresCoversFixer::class => ['*Test.php'],

--- a/tests/Sample.php
+++ b/tests/Sample.php
@@ -33,6 +33,6 @@ class Sample
     public function run(): void
     {
         /** @var string|null $description */
-        $description = true ? 'This is a description' : null;
+        $description = true ? 'This is a' . ' description' : null;
     }
 }


### PR DESCRIPTION
This PR replaces the use of ContainerConfiguration to ECSConfig, and gets rid of deprecated  SYMFONY coding standard in favor of PSR_12 